### PR TITLE
Remove Active Model dependency

### DIFF
--- a/active_fulfillment.gemspec
+++ b/active_fulfillment.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('minitest', '>= 4.7')
   s.add_development_dependency('timecop')
   s.add_development_dependency('byebug')
+  s.add_development_dependency('simplecov')
 end

--- a/active_fulfillment.gemspec
+++ b/active_fulfillment.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.summary = %q{Framework and tools for dealing with shipping, tracking and order fulfillment services.}
 
   s.add_dependency('activesupport', '>= 3.2.9')
-  s.add_dependency('activemodel', '>= 3.2.9')
   s.add_dependency('builder', '>= 2.0.0')
   s.add_dependency('nokogiri', '>= 1.6')
   s.add_dependency('active_utils', '~> 3.0')

--- a/lib/active_fulfillment.rb
+++ b/lib/active_fulfillment.rb
@@ -34,8 +34,6 @@ begin
 rescue LoadError
 end
 
-require 'active_model'
-
 require 'builder'
 require 'nokogiri'
 require 'cgi'

--- a/lib/active_fulfillment/models.rb
+++ b/lib/active_fulfillment/models.rb
@@ -1,3 +1,0 @@
-Dir[File.join(__dir__, "models/dotcom_distribution/*.rb")].each do |path|
-  require "active_fulfillment/models/dotcom_distribution/#{File.basename(path).sub(/\.rb$/, '')}"
-end

--- a/lib/active_fulfillment/models/dotcom_distribution.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution.rb
@@ -1,0 +1,15 @@
+module ActiveFulfillment
+  module DotcomDistribution
+    module Model
+      def initialize(args={})
+        args.each do |k, v|
+          public_send(:"#{k}=", v)
+        end
+      end
+    end
+  end
+end
+
+Dir[File.join(__dir__, "dotcom_distribution/*.rb")].each do |path|
+  require "active_fulfillment/models/dotcom_distribution/#{File.basename(path).sub(/\.rb$/, '')}"
+end

--- a/lib/active_fulfillment/models/dotcom_distribution/adjustment.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/adjustment.rb
@@ -2,10 +2,6 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class Adjustment
-
-      include ::ActiveModel::Model
-      include ::ActiveModel::Serializers::Xml
-
       attr_accessor :adjustment_code,
                     :adjustment_desc,
                     :dcd_identifier,

--- a/lib/active_fulfillment/models/dotcom_distribution/backorder.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/backorder.rb
@@ -2,10 +2,6 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class Backorder
-
-      include ::ActiveModel::Model
-      include ::ActiveModel::Serializers::Xml
-
       attr_accessor :carrier,
                     :dcd_order_number,
                     :dcd_order_release_number,
@@ -55,8 +51,6 @@ module ActiveFulfillment
     end
 
     class BackorderItem
-      include ::ActiveModel::Model
-
       attr_accessor :vendor,
                     :sku,
                     :quantity_pending,

--- a/lib/active_fulfillment/models/dotcom_distribution/get_order.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/get_order.rb
@@ -2,9 +2,7 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class GetOrder
-
-      include ::ActiveModel::Model
-
+      include Model
       attr_accessor :client_order_number,
                     :dcd_order_number,
                     :dcd_order_suffix,

--- a/lib/active_fulfillment/models/dotcom_distribution/inventory.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/inventory.rb
@@ -2,9 +2,7 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class Inventory
-
-      include ::ActiveModel::Model
-      include ::ActiveModel::Serializers::Xml
+      include Model
 
       attr_accessor :sku,
                     :description,

--- a/lib/active_fulfillment/models/dotcom_distribution/inventory_snapshot.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/inventory_snapshot.rb
@@ -2,10 +2,6 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class InventorySnapshot
-
-      include ::ActiveModel::Model
-      include ::ActiveModel::Serializers::Xml
-
       attr_accessor :sku,
                     :description,
                     :quantity_bod,

--- a/lib/active_fulfillment/models/dotcom_distribution/inventory_snapshot.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/inventory_snapshot.rb
@@ -2,6 +2,8 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class InventorySnapshot
+      include Model
+
       attr_accessor :sku,
                     :description,
                     :quantity_bod,

--- a/lib/active_fulfillment/models/dotcom_distribution/item_summary.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/item_summary.rb
@@ -2,9 +2,7 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class ItemSummary
-
-      include ::ActiveModel::Model
-
+      include Model
       attr_accessor :sku,
                     :description,
                     :last_receipt_date,
@@ -31,8 +29,7 @@ module ActiveFulfillment
     end
 
     class VendorItem
-      include ::ActiveModel::Model
-
+      include Model
       attr_accessor :cross_ref
     end
   end

--- a/lib/active_fulfillment/models/dotcom_distribution/post_item.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/post_item.rb
@@ -2,9 +2,7 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class PostItem
-
-      include ::ActiveModel::Model
-      include ::ActiveModel::Validations
+      include Model
 
       attr_accessor :sku,
                     :description,
@@ -31,42 +29,6 @@ module ActiveFulfillment
                     :short_name,
                     :color,
                     :size
-
-      validates_numericality_of :weight, :avg_cost, :cost, :price, greater_than_or_equal_to: 0, less_than_or_equal_to: 9999.99, allow_nil: true
-      validates_numericality_of :package_qty, only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 999999, allow_nil: true
-
-      validates_numericality_of :client_product_class, only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 9999, allow_nil: true
-      validates_numericality_of :client_product_type, only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 9999, allow_nil: true
-
-      # Y = Serial Inbound
-      # N = Serial Outbound
-      # O = Outbound
-      validates_inclusion_of :serial_indicator, in: %w(Y N O), allow_blank: true
-
-      validates_numericality_of :master_pack, only_integer: true, allow_blank: true, maximum: 999999
-
-      validates_length_of :sku, maximum: 17, allow_blank: false
-      validates_length_of :description, maximum: 30, allow_blank: false
-      validates_length_of :root_sku, maximum: 17, allow_blank: true
-      validates_length_of :item_barcode, maximum: 24, allow_blank: true
-      validates_length_of :client_company, maximum: 5, allow_blank: true
-      validates_length_of :client_department, maximum: 5, allow_blank: true
-      validates_length_of :country_of_origin, maximum: 2, allow_blank: true
-      validates_length_of :long_description, maximum: 50, allow_blank: true
-      validates_length_of :harmonized_code, maximum: 10, allow_blank: true
-      validates_length_of :manufacturing_code, maximum: 10, allow_blank: true
-      validates_length_of :style_number, maximum: 10, allow_blank: true
-      validates_length_of :short_name, maximum: 15, allow_blank: true
-      validates_length_of :color, maximum: 5, allow_blank: true
-      validates_length_of :size, maximum: 5, allow_blank: true
-
-      class UpcValidator < ActiveModel::Validator
-        def validate(record)
-          # TODO: Validate Upc
-        end
-      end
-
-      validates_with UpcValidator, fields: [:upc]
 
       def self.response_from_xml(xml)
         success = true, message = '', hash = {}, records = []

--- a/lib/active_fulfillment/models/dotcom_distribution/post_order.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/post_order.rb
@@ -17,10 +17,7 @@ module ActiveFulfillment
     #   Is a Y/N field.  If you pass us Y and we display prices on your
     #   invoice we will suppress printing the price and values.
     class PostOrder
-
-      include ::ActiveModel::Model
-      include ::ActiveModel::Validations
-      include ::ActiveModel::Serializers::Xml
+      include Model
 
       attr_accessor :order_number,
                     :order_date,
@@ -104,70 +101,6 @@ module ActiveFulfillment
          ["DHL NEXT DATE 12:00", "45"],
         ].inject({}){|h, (k,v)| h[k] = v; h}
       end
-
-      # Date expected in format yyyy-mm-dd
-      DATE_REGEX = /\d{4}-\d{2}-\d{2}/
-
-      validates_format_of :ship_date, :order_date, with: DATE_REGEX
-      validates_format_of :cancel_date, with: DATE_REGEX, allow_nil: true
-      validates_format_of :credit_card_expiration, with: /\d{2}\d{2}/, allow_nil: true
-
-      validates_length_of :order_number, :in => 1..20, allow_blank: false
-      validates_length_of :ship_via, maximum: 20, allow_blank: true
-      validates_length_of :drop_ship, maximum: 1, allow_blank: true
-      validates_length_of :pool, maximum: 24, allow_blank: true
-      validates_length_of :ok_partial_ship, maximum: 1, allow_blank: true
-      validates_length_of :special_instructions, maximum: 40, allow_blank: true
-      validates_length_of :special_messaging,  maximum: 250, allow_blank: true
-      validates_length_of :po_number, maximum: 20, allow_blank: true
-      validates_length_of :salesman, maximum: 20, allow_blank: true
-      validates_length_of :credit_card_number, maximum: 32, allow_blank: true
-      validates_length_of :credit_card_expiration, maximum: 4, allow_blank: true
-      validates_length_of :ad_code, maximum: 5, allow_blank: true
-      validates_length_of :continuity_flag, maximum: 1, allow_blank: true
-      validates_length_of :freight_terms, maximum: 20, allow_blank: true
-      validates_length_of :department, maximum: 5, allow_blank: true
-      validates_length_of :pay_terms, maximum: 5, allow_blank: true
-      validates_length_of :asn_qualifier, maximum: 5, allow_blank: true
-      validates_length_of :order_source, maximum: 8, allow_blank: true
-      validates_length_of :third_party_account, maximum: 25, allow_blank: true
-      validates_length_of :priority, maximum: 5, allow_blank: true
-      validates_length_of :retail_department, maximum: 10, allow_blank: true
-      validates_length_of :retail_store, maximum: 10, allow_blank: true
-      validates_length_of :retail_vendor, maximum: 10, allow_blank: true
-
-      validates_inclusion_of :ship_method, in: :shipping_methods
-      validates_inclusion_of :gift_order_indicator, in: %w(Y N), allow_blank: true
-
-      validates_numericality_of :tax_percent, greater_than_or_equal_to: 0, less_than: 100, allow_nil: true
-      validates_numericality_of :total_tax, :total_shipping_handling, :total_order_amount, greater_than_or_equal_to: 0
-      validates_numericality_of :declared_value, less_than_or_equal_to: 99999999.99, allow_nil: true
-      validates_numericality_of :invoice_number, only_integer: true, less_than: 4294967296, allow_nil: true
-      validates_numericality_of :total_discount, greater_than_or_equal_to: 0, less_than: 100.00, allow_nil: true
-
-      class LineItemValidator < ActiveModel::EachValidator
-        def validate_each(record, attribute, value)
-          if record.line_items
-            record.line_items.each do |li|
-              record.errors[:line_items] << li.errors unless li.valid?
-            end
-          end
-        end
-      end
-
-      class BillingInformationValidator < ActiveModel::EachValidator
-        def validate_each(record, attribute, value)
-          if record.billing_information
-            unless record.billing_information.valid?
-              record.errors[:billing_information] << record.billing_information.errors
-            end
-          end
-        end
-      end
-
-      validates_presence_of :line_items, :billing_information
-      validates :line_items, line_item: true
-      validates :billing_information, billing_information: true
 
       def store_information=(attributes)
         @store_information = Address.new(attributes)
@@ -382,8 +315,7 @@ module ActiveFulfillment
     end
 
     class LineItem
-      include ::ActiveModel::Model
-      include ::ActiveModel::Validations
+      include Model
 
       attr_accessor :sku,
                     :quantity,
@@ -394,20 +326,6 @@ module ActiveFulfillment
                     :line_number,
                     :gift_box_wrap_quantity,
                     :gift_box_wrap_type
-
-      # required arguments
-      validates_length_of :sku, maximum: 17, allow_blank: false
-      validates_length_of :line_number, maximum: 20, allow_blank: true
-      validates_length_of :client_item, maximum: 20, allow_blank: true
-      validates_numericality_of :quantity, only_integer: true, greater_than: 0
-      validates_numericality_of :tax, :price, greater_than_or_equal_to: 0,
-        less_than_or_equal_to: 99999.99
-      validates_numericality_of :shipping_handling, greater_than_or_equal_to: 0,
-        less_than_or_equal_to: 999999.99
-
-      validates_numericality_of :gift_box_wrap_quantity, only_integer: true, greater_than: 0, less_than_or_equal_to: 9999999999, allow_nil: true
-      validates_numericality_of :gift_box_wrap_type, only_integer: true, greater_than: 0, less_than_or_equal_to: 9999, allow_nil: true
-      validates_numericality_of :line_number, only_integer: true, greater_than: 0, allow_nil: true
 
       def price
         @price || 0
@@ -423,9 +341,7 @@ module ActiveFulfillment
     end
 
     class Address
-      include ::ActiveModel::Model
-      include ::ActiveModel::Validations
-
+      include Model
       attr_accessor :customer_number,
                     :name,
                     :company,
@@ -439,17 +355,6 @@ module ActiveFulfillment
                     :iso_country_code,
                     :phone,
                     :email
-
-      # required arguments
-      validates_length_of :name, :address1, maximum: 30, allow_blank: false
-      validates_length_of :city, maximum: 20, allow_blank: false
-      validates_length_of :state, maximum: 2, allow_blank: false
-      validates_length_of :zip, maximum: 10, allow_blank: false
-
-      validates_length_of :customer_number, maximum: 19, allow_blank: true
-      validates_length_of :address2, :address3, maximum: 30, allow_blank: true
-      validates_length_of :country, maximum: 2, allow_blank: true
-      validates :phone, presence: true, length: {maximum: 19}, if: -> { country.present? }
     end
 
   end

--- a/lib/active_fulfillment/models/dotcom_distribution/purchase_order.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/purchase_order.rb
@@ -24,10 +24,13 @@ module ActiveFulfillment
       validates :items, item: true
 
       def items=(attributes)
-        @items ||= []
         attributes.each do |params|
-          @items.push(PostItem.new(params))
+          items.push(PostItem.new(params))
         end
+      end
+
+      def items
+        @items ||= []
       end
 
       def to_xml
@@ -46,7 +49,7 @@ module ActiveFulfillment
           xml.send(:"priority-date", self.priority_date)
           xml.send(:"expected-on-dock", self.expected_on_dock)
           xml.send(:"items") do
-            Array(self.items).each do |item|
+            Array(items).each do |item|
               item.send(:item_to_xml, xml)
             end
           end

--- a/lib/active_fulfillment/models/dotcom_distribution/purchase_order.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/purchase_order.rb
@@ -2,26 +2,11 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class PurchaseOrder
-
-      include ::ActiveModel::Model
-      include ::ActiveModel::Validations
-
+      include Model
       attr_accessor :po_number,
                     :priority_date,
                     :expected_on_dock,
                     :items
-
-      validates_length_of :po_number, maximum: 30, allow_blank: false
-
-      class ItemValidator < ActiveModel::EachValidator
-        def validate_each(record, attribute, value)
-          record.items.each do |li|
-            record.errors[:items] << li.errors unless li.valid?
-          end
-        end
-      end
-
-      validates :items, item: true
 
       def items=(attributes)
         attributes.each do |params|

--- a/lib/active_fulfillment/models/dotcom_distribution/return.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/return.rb
@@ -2,10 +2,7 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class Return
-
-      include ::ActiveModel::Model
-      include ::ActiveModel::Serializers::Xml
-
+      include Model
       attr_accessor :dcd_return_number,
                     :department,
                     :original_order_number,
@@ -43,9 +40,7 @@ module ActiveFulfillment
     end
 
     class ReturnItem
-
-      include ::ActiveModel::Model
-
+      include Model
       attr_accessor :sku,
                     :quantity_returned,
                     :line_number,

--- a/lib/active_fulfillment/models/dotcom_distribution/ship_method.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/ship_method.rb
@@ -2,20 +2,12 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class ShipMethod
-
-      include ::ActiveModel::Model
-      include ::ActiveModel::Validations
-      include ::ActiveModel::Serializers::Xml
+      include Model
 
       attr_accessor :carrier,
                     :service,
                     :shipping_code,
                     :shipping_description
-
-      validates_length_of :carrier, maximum: 20, allow_blank: false
-      validates_length_of :service, maximum: 20, allow_blank: false
-      validates_length_of :shipping_code, maximum: 40, allow_blank: false
-      validates_length_of :shipping_description, maximum: 300, allow_blank: false
 
       def self.response_from_xml(xml)
         success = true, message = '', hash = {}, records = []

--- a/lib/active_fulfillment/models/dotcom_distribution/shipment.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/shipment.rb
@@ -2,10 +2,7 @@ module ActiveFulfillment
   module DotcomDistribution
 
     class Shipment
-
-      include ::ActiveModel::Model
-      include ::ActiveModel::Validations
-      include ::ActiveModel::Serializers::Xml
+      include Model
 
       attr_accessor :client_order_number,
                     :customer_number,
@@ -78,7 +75,7 @@ module ActiveFulfillment
     end
 
     class ShipItem
-      include ::ActiveModel::Model
+      include Model
 
       attr_accessor :carrier,
                     :carton_id,

--- a/lib/active_fulfillment/services/dotcom_distribution.rb
+++ b/lib/active_fulfillment/services/dotcom_distribution.rb
@@ -25,7 +25,6 @@ module ActiveFulfillment
     #   action: self explanatory I think
     #   endpoint: DotCom's endpoint. for instance -> https://cwa.dotcomdistribution.com/dcd_api_test/DCDAPIService.svc/item
     #   class: The class that will parse our response
-
     SERVICE_ENDPOINTS = {
       fulfillment: ["order", PostOrder],
       purchase_order: ["purchase_order", PurchaseOrder],
@@ -37,31 +36,8 @@ module ActiveFulfillment
       fetch_tracking_data: ["shipment", Shipment],
       adjustment: ["adjustment", Adjustment],
       item_summary: ["item", ItemSummary],
-      inventory_by_status: ["inventory_by_status"],
       inventory_snapshot: ["inventory_snapshot", InventorySnapshot],
-      stockstatus: ["stockstatus"],
-      receipt: ["receipt"],
-      nonpo_receipt: ["nonpo_receipt"],
-      backorder: ["backorder"],
-      billing_summary: ["billingsummary"],
-      billing_detail: ["billingdetail"],
-      receiving_sla: ["receiving_sla"]
     }
-
-    # Many of these get requests are handled by +method_missing+.
-    #
-    #  Example:
-    #    service = ActiveFulfillment::DotcomDistributionService.new({username: 'test', password: 'test'})
-    #    # or      ActiveFulfillment::Base.service('dotcom_distribution').new({username: 'test', password: 'test'})
-    #    service.receipt({fromReceiptDate: '2010-10-01', toReceiptDate: '2010-10-02'})
-    #
-    def method_missing(method_sym, *arguments, &block)
-      if SERVICE_ENDPOINTS.keys.include?(method_sym)
-        self.send(:get, method_sym, nil, arguments.first)
-      else
-        super
-      end
-    end
 
     attr_reader :base_url
 
@@ -197,21 +173,8 @@ module ActiveFulfillment
     end
 
     def parse_response(action, xml)
-      if SERVICE_ENDPOINTS[action].size == 2
-        klass = SERVICE_ENDPOINTS[action][1]
-        klass.response_from_xml(xml)
-      else
-        begin
-          klass = ("ActiveFulfillment::DotcomDistribution::" + (action.to_s.classify)).constantize
-          if klass.respond_to?(:response_from_xml)
-            klass.response_from_xml(xml)
-          else
-            raise "response_from_xml not implemented in #{klass}"
-          end
-        rescue NameError => e
-          raise ArgumentError, "Unknown action #{action}"
-        end
-      end
+      klass = SERVICE_ENDPOINTS[action][1]
+      klass.response_from_xml(xml)
     end
 
   end

--- a/test/fixtures/xml/dotcom_distribution/inventory_for_item.xml
+++ b/test/fixtures/xml/dotcom_distribution/inventory_for_item.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <items>
+    <item>
+      <sku>text</sku>
+      <desciption>text</desciption>
+      <product_group>text</product_group>
+      <quantity_available>0</quantity_available>
+      <quantity_onhand>0</quantity_onhand>
+      <quantity_demand>0</quantity_demand>
+      <quantity_backordered>0</quantity_backordered>
+      <quantity_pending>0</quantity_pending>
+      <quantity_unavailable>0</quantity_unavailable>
+      <quantity_reserved>0</quantity_reserved>
+    </item>
+  </items>
+</response>

--- a/test/fixtures/xml/dotcom_distribution/item_summary.xml
+++ b/test/fixtures/xml/dotcom_distribution/item_summary.xml
@@ -1,0 +1,15 @@
+<response xmlns="http://dcd/datacontracts/iteminfo" xmlns:i="http://www.w3.org/2001/XMLSchema- instance">
+  <items_info xmlns:a="http://schemas.datacontract.org/2004/07/DCDAPIService">
+    <a:item_info>
+      <a:item_description>Cassie Cardigan</a:item_description>
+      <a:last_receipt_date>7/27/2012 2:53:00 PM</a:last_receipt_date>
+      <a:sku>360-103053-DEW-M</a:sku>
+      <a:upc_num />
+      <a:vendor_items>
+        <a:vendor_item>
+          <a:vendor_cross_ref>846255082961</a:vendor_cross_ref>
+        </a:vendor_item>
+      </a:vendor_items>
+    </a:item_info>
+  </items_info>
+</response>

--- a/test/fixtures/xml/dotcom_distribution/returns_response.xml
+++ b/test/fixtures/xml/dotcom_distribution/returns_response.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <returns>
+    <return>
+      <items>
+        <item>
+          <sku>text</sku>
+          <quantity-returned>0</quantity-returned>
+          <line-number>0</line-number>
+          <item-disposition>text</item-disposition>
+          <returns-reason-code>0</returns-reason-code>
+        </item>
+      </items>
+      <department>text</department>
+      <original-order-number>text</original-order-number>
+      <dcd-return-number>0</dcd-return-number>
+      <return-date>1967-08-13</return-date>
+      <original-ship-date>1967-08-13</original-ship-date>
+    </return>
+  </returns>
+</response>

--- a/test/fixtures/xml/dotcom_distribution/shipment_information_for_order.xml
+++ b/test/fixtures/xml/dotcom_distribution/shipment_information_for_order.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <shipments>
+    <a:shipment>
+      <a:client_order_number>4E717D91B990</a:client_order_number>
+      <a:customer_number>lass95842</a:customer_number>
+      <a:dcd_order_number>9004859200</a:dcd_order_number>
+      <a:order_date>10/12/2011 12:00:00 AM</a:order_date>
+      <a:order_shipping_handling>0.00</a:order_shipping_handling>
+      <a:order_status>Shipped</a:order_status>
+      <a:order_subtotal>0.0000</a:order_subtotal>
+      <a:order_tax>0.00</a:order_tax>
+      <a:order_total>0.0000</a:order_total>
+      <a:ship_date>10/13/2011</a:ship_date>
+      <a:ship_items>
+        <a:ship_item>
+          <a:carrier>UPS</a:carrier>
+          <a:carton_id>C123456789</a:carton_id>
+          <a:item_description> no size Tin Word Halloween Or</a:item_description>
+          <a:item_unit_price>0.00</a:item_unit_price>
+          <a:order_line_number>1</a:order_line_number>
+          <a:client_line_number>1</a:client_line_number>
+          <a:quantity_shipped>1.00</a:quantity_shipped>
+          <a:serial_lot_number />
+          <a:service>SurePost</a:service>
+          <a:sku>PRI-E61-B1C-D41</a:sku>
+          <a:tracking_number>1ZX78240YW71511871</a:tracking_number>
+        </a:ship_item>
+      </a:ship_items>
+      <a:ship_weight>0.95</a:ship_weight>
+      <a:shipto_addr1>7220 Candlestick Way</a:shipto_addr1>
+      <a:shipto_addr2 />
+      <a:shipto_city>Sacramento</a:shipto_city>
+      <a:shipto_email_address>crazy4chows@sbcglobal.net</a:shipto_email_address>
+      <a:shipto_name>Cheryl Douglass</a:shipto_name>
+      <a:shipto_state>CA</a:shipto_state>
+      <a:shipto_zip>95842</a:shipto_zip>
+    </a:shipment>
+   </shipments>
+</response>

--- a/test/fixtures/xml/dotcom_distribution/single_order_status_response.xml
+++ b/test/fixtures/xml/dotcom_distribution/single_order_status_response.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <orders>
+    <order>
+      <client-order-number>text</client-order-number>
+      <dcd-order-number>text</dcd-order-number>
+      <dcd-order-suffix>text</dcd-order-suffix>
+      <order-status>text</order-status>
+      <ship_date>2010-03-04</ship_date>
+    </order>
+  </orders>
+</response>

--- a/test/remote/dotcom_distribution_test.rb
+++ b/test/remote/dotcom_distribution_test.rb
@@ -3,6 +3,12 @@ require 'test_helper'
 class RemoteDotcomIntegrationTest < Minitest::Test
   include ActiveFulfillment::Test::Fixtures
 
+  DOTCOM_MANUAL_TEST = "Dotcom requires manual testing for this item".freeze
+
+  def requires_manual_test!
+    skip DOTCOM_MANUAL_TEST unless ENV["DOTCOM_MANUAL_TEST"]
+  end
+
   def setup
     ActiveFulfillment::Base.mode = :test
     @service = ActiveFulfillment::DotcomDistributionService.new(fixtures(:dotcom_distribution))
@@ -81,12 +87,14 @@ class RemoteDotcomIntegrationTest < Minitest::Test
   end
 
   def test_successful_create_order
+    requires_manual_test!
     response = @service.fulfill(SecureRandom.hex(10), @address, @line_items, @options)
     # TODO: This requires the item in @line_items to exist
     assert_nil response
   end
 
   def test_order_multiple_line_items
+    requires_manual_test!
     @line_items.push({
       sku: "Test 2",
       line_number: 1,
@@ -121,6 +129,7 @@ class RemoteDotcomIntegrationTest < Minitest::Test
   end
 
   def test_get_inventory
+    requires_manual_test!
     # TODO: test with some inventory data. Currently returns empty
     response = @service.inventory_snapshot(invDate: Date.today.to_s)
     assert response.success?
@@ -128,6 +137,7 @@ class RemoteDotcomIntegrationTest < Minitest::Test
   end
 
   def test_returns
+    requires_manual_test!
     response = @service.returns(fromReturnDate: "2001-01-01", toReturnDate: Date.today.to_s)
     assert response.success?
     refute_empty response.data

--- a/test/remote/dotcom_distribution_test.rb
+++ b/test/remote/dotcom_distribution_test.rb
@@ -128,9 +128,9 @@ class RemoteDotcomIntegrationTest < Minitest::Test
     refute_empty response.data
   end
 
-  def test_get_inventory
+  def test_get_inventory_snapshot
     requires_manual_test!
-    # TODO: test with some inventory data. Currently returns empty
+
     response = @service.inventory_snapshot(invDate: Date.today.to_s)
     assert response.success?
     refute_empty response.data

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,8 @@
 require 'bundler/setup'
 
+require 'simplecov'
+SimpleCov.start
+
 require 'active_fulfillment'
 
 require 'minitest/autorun'

--- a/test/unit/models/dotcom_distribution/post_order_test.rb
+++ b/test/unit/models/dotcom_distribution/post_order_test.rb
@@ -61,27 +61,6 @@ class PostOrderTest < Minitest::Test
     @order_doc = Nokogiri.XML(@post_order.to_xml)
   end
 
-  def test_address_validation
-    address = Address.new(address_attributes)
-    assert address.valid?
-    address.country = "CO"
-    refute address.valid?
-    address.phone = "1113334444"
-    assert address.valid?
-  end
-
-  def test_line_item_validation
-    line_item = LineItem.new(line_item_attributes)
-    assert line_item.valid?
-  end
-
-  def test_validate_post_order
-    @post_order = PostOrder.new(required_attributes)
-    @post_order.valid?
-    puts @post_order.line_items.first.errors.full_messages
-    assert @post_order.valid?, "got errors #{@post_order.errors.full_messages}"
-  end
-
   def test_post_order_top_level_serialization
     order = @order_doc.xpath("//order")
 

--- a/test/unit/services/dotcom_distribution_test.rb
+++ b/test/unit/services/dotcom_distribution_test.rb
@@ -1,0 +1,300 @@
+require 'test_helper'
+
+class DotcomDistributionTest < Minitest::Test
+  include ActiveFulfillment::Test::Fixtures
+
+  def setup
+    @endpoints = ActiveFulfillment::DotcomDistributionService::SERVICE_ENDPOINTS
+    @service = ActiveFulfillment::DotcomDistributionService.new(
+      username: 'u', password: 'p'
+    )
+    @item = {
+      sku: "Test",
+      description: "a",
+      upc: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      weight: 100.12,
+      cost: 1000.12,
+      price: 1000.12,
+      root_sku: "aaaaaaaaaaaaaaaaa",
+      package_qty: 10,
+      serial_indicator: "Y",
+      client_company: "aaaaa",
+      client_department: "aaaaa",
+      client_product_class: 1234,
+      client_product_type: 1234,
+      avg_cost: 50.12,
+      master_pack: 123456,
+      item_barcode: "aaaaaaaaaaaaaaaaaaaaaaaa",
+      harmonized_code: "aaaaaaaaa",
+      manufacturing_code: "aaaaaaaaaa",
+      style_number: "aaaaaaaaaa",
+      short_name: "aaaaaaaaaa",
+      color: "aaaa",
+      size: "aaaaa",
+      long_description: "aaaaaaaaaa"
+    }
+    @line_items =  [
+      {
+        sku: "Test",
+        line_number: 1,
+        client_item: "abc",
+        quantity: 1,
+        gift_box_wrap_quantity: 1,
+        gift_box_wrap_type: 1
+      }
+    ]
+    @address = {
+      customer_number: "12345",
+      name: "Chloe Isabel",
+      address1: "123 abc",
+      city: "Miami",
+      state: "FL",
+      zip: "33018",
+    }
+    @options = {
+      ship_date: Time.current.strftime("%Y-%m-%d"),
+      order_date: Time.current.strftime("%Y-%m-%d"),
+      ship_method: "01",
+      tax_percent: 5,
+      billing_information: @address,
+    }
+    @purchase_order = {
+      po_number: "a",
+      priority_date: Time.now.strftime("%Y-%m-%d"),
+      expected_on_dock: Time.now.strftime("%Y-%m-%d"),
+      items: [@item.merge(quantity: 1)]
+    }
+  end
+
+  def test_fulfillment_successful
+    order_id = "12345678"
+    @service.expects(:ssl_post).with do |url, data, headers|
+      url.end_with?("/" + @endpoints[:fulfillment].first) &&
+        data.include?("<order-number>#{order_id}</order-number>")
+    end.returns(successful_fulfillment_response)
+    response = @service.fulfill(order_id, @address, @line_items, @options)
+    # TODO it may be better to actually return a Response object with success
+    # assert response.success?
+    assert_nil response
+  end
+
+  def test_fulfillment_invalid_arguments
+    @service.expects(:ssl_post).returns(invalid_post_order_response)
+    response = @service.fulfill("12345678", @address, @line_items, @options)
+
+    refute response.success?
+    refute_empty response.params["data"]
+    errors = response.params["data"]
+    assert_equal 1, errors.size
+    error = errors.first
+    assert_equal "The 'ship-date' element is invalid - The value '2011/03/12' is invalid according to its datatype 'Date' - The string '2011/03/12' is not a valid XsdDateTime value.", error[:error_description]
+    assert_equal "123", error[:order_number]
+  end
+
+  [:order_date, :ship_date, :ship_method, :tax_percent, :billing_information].each do |attr|
+    define_method(:"test_missing_#{attr}") do
+      @options.delete(attr)
+      assert_raises(ArgumentError) {
+        @service.fulfill("12345678", @address, @line_items, @options)
+      }
+    end
+  end
+
+  def test_get_inventory_for_all
+    @service.expects(:ssl_get).with do |url, data, headers|
+      url.end_with?(@endpoints[:fetch_stock_levels].first)
+    end.returns(xml_fixture("dotcom_distribution/inventory_for_item"))
+    response = @service.fetch_stock_levels
+    assert response.success?
+  end
+
+  def test_get_inventory_for_item
+    item_id = "12345"
+    @service.expects(:ssl_get).with do |url, data, headers|
+      url.end_with?(@endpoints[:fetch_stock_levels].first + "/" + item_id)
+    end.returns(xml_fixture("dotcom_distribution/inventory_for_item"))
+    response = @service.fetch_stock_levels(item_id: item_id)
+    assert response.success?
+  end
+
+  def test_fetch_tracking_data
+    order_id = "tracking_data_123456789"
+    @service.expects(:ssl_get).with do |url, data, headers|
+      url.end_with?(@endpoints[:fetch_tracking_data].first + "/" + order_id)
+    end.returns(xml_fixture("dotcom_distribution/shipment_information_for_order"))
+
+    response = @service.fetch_tracking_data([order_id])
+    assert response.success?
+  end
+
+  def test_fetch_tracking_data_without_order_ids_fails_without_options
+    assert_raises(ArgumentError) { @service.fetch_tracking_data([]) }
+  end
+
+  def test_fetch_tracking_data_without_order_ids
+    @service.expects(:ssl_get).with do |url, data, headers|
+      url.end_with?(@endpoints[:fetch_tracking_data].first + "?fromShipDate=2010-1-1&toShipDate=2010-1-1&dept=A&kitonly=1")
+    end.returns(xml_fixture("dotcom_distribution/shipment_information_for_order"))
+
+    response = @service.fetch_tracking_data([], fromShipDate: "2010-1-1", toShipDate: "2010-1-1", dept: "A", kitonly: "1")
+    assert response.success?
+  end
+
+  def test_purchase_order_successful
+    @service.expects(:ssl_post).returns(successful_purchase_order_response)
+    response = @service.purchase_order(po_number: "abc123")
+    # TODO: we should be using Response.new success with success rather than nil
+    assert_nil response
+  end
+
+  def test_purchase_order_invalid_purchase_order
+    @service.expects(:ssl_post).returns(invalid_purchase_order_response)
+    response = @service.purchase_order(po_number: "foobar")
+    refute response.success?
+  end
+
+  def test_order_status_successful_with_order_number
+    order_number = "1234567890"
+    @service.expects(:ssl_get).with do |url, headers|
+      url.end_with?(@endpoints[:order_status].first + "/"+ order_number)
+    end.returns(xml_fixture("dotcom_distribution/single_order_status_response"))
+    response = @service.order_status(order_number: order_number)
+    assert response.success?
+  end
+
+  def test_order_status_successful_without_order_number
+    query = { fromOrdDate: "2010-1-1", toOrdDate: "2010-1-1" }
+    @service.expects(:ssl_get).with do |url, headers|
+      url.end_with?(@endpoints[:order_status].first + "?" + query.to_query)
+    end.returns(xml_fixture("dotcom_distribution/single_order_status_response"))
+    response = @service.order_status(query)
+    assert response.success?
+  end
+
+  def test_order_status_invalid_arguments
+    assert_raises(ArgumentError) { @service.order_status }
+  end
+
+  def test_returns_successful
+    query = { fromReturnDate: "2010-1-1", toReturnDate: "2010-1-1" }
+    @service.expects(:ssl_get).with do |url, headers|
+      url.end_with?(@endpoints[:returns].first + "?" + query.to_query)
+    end.returns(xml_fixture("dotcom_distribution/returns_response"))
+    response = @service.returns(query)
+    assert response.success?
+  end
+
+  def test_returns_invalid_arguments
+    assert_raises(ArgumentError) { @service.returns }
+  end
+
+  def test_post_item_successful
+    @service.expects(:ssl_post).returns(successful_post_item_response)
+    response = @service.post_item(@item)
+    # TODO: return a Response object rather than nil
+    assert_nil response
+  end
+
+  def test_post_items_with_errors
+    @service.expects(:ssl_post).returns(invalid_post_item_response)
+    response = @service.post_item(@item)
+    refute response.success?
+  end
+
+  def test_post_item_invalid_arguments
+    response = @service.post_item
+    refute response.success?
+    assert_instance_of ActiveModel::Errors, response.params["data"]
+    refute_empty response.params["data"].messages
+  end
+
+  def test_item_summary_successful
+    @service.expects(:ssl_get).with do |url, headers|
+      url.end_with?(@endpoints[:item_summary].first)
+    end.returns(xml_fixture("dotcom_distribution/item_summary"))
+    response = @service.item_summary
+    assert response.success?
+  end
+
+  def test_single_item_summary_successful
+    sku = "ABC-123"
+    @service.expects(:ssl_get).with do |url, headers|
+      url.end_with?(@endpoints[:item_summary].first + "/" + sku)
+    end
+    response = @service.item_summary(sku: sku)
+    assert response.success?
+  end
+
+  private
+  def successful_post_item_response
+  <<-XML
+<response xmlns="http://dcd/datacontracts/post_item" xmlns:i="http://www.w3.org/2001/XMLSchema- instance">
+  <item_errors xmlns:a="http://schemas.datacontract.org/2004/07/DCDAPIService">
+  </item_errors>
+</response>
+  XML
+  end
+
+  def invalid_post_item_response
+  <<-XML
+<response xmlns="http://dcd/datacontracts/post_item" xmlns:i="http://www.w3.org/2001/XMLSchema- instance">
+  <item_errors xmlns:a="http://schemas.datacontract.org/2004/07/DCDAPIService">
+    <a:item_error>
+      <a:error_description>The 'sku' element is invalid - The value '' is invalid according to its datatype 'String' - The actual length is less than the MinLength value.</a:error_description>
+      <a:sku/>
+    </a:item_error>
+    <a:item_error>
+      <a:error_description>The 'description' element is invalid - The value '' is invalid according to its datatype 'String' - The actual length is less than the MinLength value.</a:error_description>
+      <a:sku>a</a:sku>
+    </a:item_error>
+  </item_errors>
+</response>
+  XML
+  end
+
+  def successful_purchase_order_response
+  <<-XML
+<response xmlns="http://dcd/datacontracts/post_purchase_order" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <purchase_order_errors xmlns:a="http://schemas.datacontract.org/2004/07/DCDAPIService">
+  </purchase_order_errors>
+</response>
+  XML
+  end
+
+  def invalid_purchase_order_response
+  <<-XML
+<response xmlns="http://dcd/datacontracts/post_purchase_order" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <purchase_order_errors xmlns:a="http://schemas.datacontract.org/2004/07/DCDAPIService">
+    <a:purchase_order_error>
+      <a:error_description>The 'description' element is invalid - The value 'abfdsbdfbfdbfdbbbbbbbbbbbbbbbbbbb' is invalid according to its datatype 'String' - The actual length is greater than the MaxLength value.</a:error_description>
+      <a:purchase_order_number>a</a:purchase_order_number>
+    </a:purchase_order_error>
+  </purchase_order_errors>
+</response>
+  XML
+  end
+
+  def successful_fulfillment_response
+  <<-XML
+<response xmlns="http://dcd/datacontracts/post_order" xmlns:i="http://www.w3.org/2001/XMLSchema- instance">
+  <order_errors xmlns:a="http://schemas.datacontract.org/2004/07/DCDAPIService">
+  </order_errors>
+</response>
+  XML
+  end
+
+  def invalid_post_order_response
+  <<-XML
+<response xmlns="http://dcd/datacontracts/post_order" xmlns:i="http://www.w3.org/2001/XMLSchema- instance">
+  <order_errors xmlns:a="http://schemas.datacontract.org/2004/07/DCDAPIService">
+    <a:order_error>
+      <a:error_description>The 'ship-date' element is invalid - The value '2011/03/12' is invalid according to its datatype 'Date' - The string '2011/03/12' is not a valid XsdDateTime value.</a:error_description>
+      <a:order_number>123</a:order_number>
+    </a:order_error>
+  </order_errors>
+</response>
+  XML
+  end
+
+end
+


### PR DESCRIPTION
Removed a bunch of APIs and method_missing until we actually need it.

Removing Active Model will allow arguments to be passed down to the Dotcom API and let them handle with argument validation so we don't have to keep parity. 
