### PR TITLE
Fixed bad response XML methods error

### DIFF
--- a/lib/active_fulfillment/models/dotcom_distribution/adjustment.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/adjustment.rb
@@ -17,27 +17,23 @@ module ActiveFulfillment
 
 
       def self.response_from_xml(xml)
-        success = true, message = '', hash = {}, records = []
+        success = true, message = '', records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//item").each do |el|
-          hash[:adjustment_code] = el.at('.//adjustment_code').try(:text)
-          hash[:adjustment_desc] = el.at('.//adjustment_desc').try(:text)
-          hash[:dcd_identifier] = el.at('.//dcd_identifier').try(:text)
-          hash[:old_stock_status_code] = el.at('.//old_stock_status_code').try(:text)
-          hash[:old_stock_status_desc] = el.at('.//old_stock_status_desc').try(:text)
-          hash[:quantity] = el.at('.//quantity').try(:text)
-          hash[:sku] = el.at('.//sku').try(:text)
-          hash[:stock_status_code] = el.at('.//stock_status_code').try(:text)
-          hash[:stock_status_desc] = el.at('.//stock_status_desc').try(:text)
-          hash[:transaction_code] = el.at('.//transaction_code').try(:text)
-          hash[:transaction_datetime] = el.at('.//transaction_datetime').try(:text)
-          hash[:transaction_desc] = el.at('.//transaction_desc').try(:text)
-
-          records << Adjustment.new(hash)
+          records << Adjustment.new({adjustment_code: el.at('.//adjustment_code').try(:text),
+                                     adjustment_desc: el.at('.//adjustment_desc').try(:text),
+                                     dcd_identifier: el.at('.//dcd_identifier').try(:text),
+                                     old_stock_status_code: el.at('.//old_stock_status_code').try(:text),
+                                     old_stock_status_desc: el.at('.//old_stock_status_desc').try(:text),
+                                     quantity: el.at('.//quantity').try(:text),
+                                     sku: el.at('.//sku').try(:text),
+                                     stock_status_code: el.at('.//stock_status_code').try(:text),
+                                     stock_status_desc: el.at('.//stock_status_desc').try(:text),
+                                     transaction_code: el.at('.//transaction_code').try(:text),
+                                     transaction_datetime: el.at('.//transaction_datetime').try(:text),
+                                     transaction_desc: el.at('.//transaction_desc').try(:text)})
         end
-
         Response.new(true, '', {data: records})
       end
     end

--- a/lib/active_fulfillment/models/dotcom_distribution/backorder.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/backorder.rb
@@ -15,37 +15,30 @@ module ActiveFulfillment
 
 
       def self.response_from_xml(xml)
-        success = true, message = '', hash = {}, records = []
+        success = true, message = '', records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//backorder").each do |el|
-          hash[:carrier] = el.at('.//carrier').try(:text)
-          hash[:dcd_order_number] = el.at('.//dcd_order_number').try(:text)
-          hash[:dcd_order_release_number] = el.at('.//dcd_order_release_number').try(:text)
-          hash[:department] = el.at('.//department').try(:text)
-          hash[:order_date] = el.at('.//order_date').try(:text)
-          hash[:order_number] = el.at('.//order_number').try(:text)
-          hash[:priority_date] = el.at('.//priority_date').try(:text)
-          hash[:ship_to_email] = el.at('.//ship_to_email').try(:text)
-          hash[:ship_to_name] = el.at('.//ship_to_name').try(:text)
-
+          hash = {carrier: el.at('.//carrier').try(:text),
+                  dcd_order_number: el.at('.//dcd_order_number').try(:text),
+                  dcd_order_release_number: el.at('.//dcd_order_release_number').try(:text),
+                  department: el.at('.//department').try(:text),
+                  order_date: el.at('.//order_date').try(:text),
+                  order_number: el.at('.//order_number').try(:text),
+                  priority_date: el.at('.//priority_date').try(:text),
+                  ship_to_email: el.at('.//ship_to_email').try(:text),
+                  ship_to_name: el.at('.//ship_to_name').try(:text)}
           hash[:backorder_items] = [] if hash[:backorder_items].nil? && el.xpath('.//bo_items').size > 0
-
           el.xpath('.//bo_item').each do |item|
-            h = {}
-            h[:vendor] = item.at('.//vendor').try(:text)
-            h[:sku] = item.at('.//sku').try(:text)
-            h[:quantity_pending] = item.at('.//quantity_pending').try(:text)
-            h[:quantity_backordered] = item.at('.//quantity_backordered').try(:text)
-            h[:quantity_available] = item.at('.//quantity_available').try(:text)
-
-            hash[:backorder_items] << BackorderItem.new(h)
+            hash[:backorder_items] <<
+              BackorderItem.new({vendor: item.at('.//vendor').try(:text),
+                                 sku: item.at('.//sku').try(:text),
+                                 quantity_pending: item.at('.//quantity_pending').try(:text),
+                                 quantity_backordered: item.at('.//quantity_backordered').try(:text),
+                                 quantity_available: item.at('.//quantity_available').try(:text)})
           end
-
           records << Backorder.new(hash)
         end
-
         Response.new(true, '', {data: records})
       end
     end
@@ -56,8 +49,6 @@ module ActiveFulfillment
                     :quantity_pending,
                     :quantity_backordered,
                     :quantity_available
-
     end
-
   end
 end

--- a/lib/active_fulfillment/models/dotcom_distribution/get_order.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/get_order.rb
@@ -11,24 +11,18 @@ module ActiveFulfillment
 
 
       def self.response_from_xml(xml)
-        success = true, message = '', hash = {}, records = []
+        success = true, message = '', records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//order").each do |el|
-          hash[:client_order_number] = el.at('.//client_order_number').try(:text)
-          hash[:dcd_order_number] = el.at('.//dcd_order_number').try(:text)
-          hash[:dcd_order_suffix] = el.at('.//dcd_order_suffix').try(:text)
-          hash[:order_status] = el.at('.//order_status').try(:text)
-          hash[:ship_date] = el.at('.//ship_date').try(:text)
-
-          records << GetOrder.new(hash)
+          records << GetOrder.new({client_order_number: el.at('.//client_order_number').try(:text),
+                                   dcd_order_number: el.at('.//dcd_order_number').try(:text),
+                                   dcd_order_suffix: el.at('.//dcd_order_suffix').try(:text),
+                                   order_status: el.at('.//order_status').try(:text),
+                                   ship_date: el.at('.//ship_date').try(:text)})
         end
-
         Response.new(true, '', {data: records})
       end
-
     end
-
   end
 end

--- a/lib/active_fulfillment/models/dotcom_distribution/get_purchase_order.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/get_purchase_order.rb
@@ -16,7 +16,6 @@ module ActiveFulfillment
         success = true, message = '', hash = {}, records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//purchase-order").each do |el|
           hash[:po_number] = el.at('.//po-number').try(:text)
           hash[:po_status] = el.at('.//po-status').try(:text)
@@ -24,7 +23,6 @@ module ActiveFulfillment
           hash[:po_date] = el.at('.//po-date').try(:text)
           hash[:priority_date] = el.at('.//priority-date').try(:text)
           hash[:expected_date] = el.at('.//expected-date').try(:text)
-
           hash[:po_items] = el.xpath('.//po-items//po-item').collect do |item|
             PurchaseOrderItem.new(sku: item.at('.//sku').try(:text),
                                   item_description: item.at('.//item-description').try(:text),

--- a/lib/active_fulfillment/models/dotcom_distribution/inventory.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/inventory.rb
@@ -17,28 +17,24 @@ module ActiveFulfillment
 
 
       def self.response_from_xml(xml)
-        success = true, message = '', hash = {}, records = []
+        success = true, message = '', records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
 
         doc.xpath("//item").each do |el|
-          hash[:sku] = el.at('.//sku').try(:text)
-          hash[:description] = el.at('.//description').try(:text)
-          hash[:product_group] = el.at('.//product_group').try(:text)
-          hash[:quantity_available] = el.at('.//quantity_available').try(:text)
-          hash[:quantity_onhand] = el.at('.//quantity_onhand').try(:text)
-          hash[:quantity_demand] = el.at('.//quantity_demand').try(:text)
-          hash[:quantity_backordered] = el.at('.//quantity_backordered').try(:text)
-          hash[:quantity_pending] = el.at('.//quantity_pending').try(:text)
-          hash[:quantity_unavailable] = el.at('.//quantity_unavailable').try(:text)
-          hash[:quantity_reserved] = el.at('.//quantity_reserved').try(:text)
-
-          records << Inventory.new(hash)
+          records << Inventory.new({sku: el.at('.//sku').try(:text),
+                                    description: el.at('.//description').try(:text),
+                                    product_group: el.at('.//product_group').try(:text),
+                                    quantity_available: el.at('.//quantity_available').try(:text),
+                                    quantity_onhand: el.at('.//quantity_onhand').try(:text),
+                                    quantity_demand: el.at('.//quantity_demand').try(:text),
+                                    quantity_backordered: el.at('.//quantity_backordered').try(:text),
+                                    quantity_pending: el.at('.//quantity_pending').try(:text),
+                                    quantity_unavailable: el.at('.//quantity_unavailable').try(:text),
+                                    quantity_reserved: el.at('.//quantity_reserved').try(:text)})
         end
-
         Response.new(true, '', {data: records})
       end
     end
-
   end
 end

--- a/lib/active_fulfillment/models/dotcom_distribution/inventory_snapshot.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/inventory_snapshot.rb
@@ -16,28 +16,23 @@ module ActiveFulfillment
                     :transaction_date
 
       def self.response_from_xml(xml)
-        success = true, message = '', hash = {}, records = []
+        success = true, message = '', records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//inv_snapshot_item").each do |el|
-          hash[:sku] = el.at('.//sku').try(:text)
-          hash[:description] = el.at('.//description').try(:text)
-          hash[:quantity_bod] = el.at('.//begin_bal').try(:text)
-          hash[:quantity_eod] = el.at('.//end_bal').try(:text)
-          hash[:quantity_adjusted] = el.at('.//adj_qty').try(:text)
-          hash[:quantity_received] = el.at('.//rcpt_qty').try(:text)
-          hash[:quantity_returned] = el.at('.//ret_qty').try(:text)
-          hash[:quantity_shipped] = el.at('.//shp_qty').try(:text)
-          hash[:quantity_unavailable_adjustments] = el.at('.//uad_qty').try(:text)
-          hash[:transaction_date] = el.at('.//trans_date').try(:text)
-
-          records << InventorySnapshot.new(hash)
+          records << InventorySnapshot.new({sku: el.at('.//sku').try(:text),
+                                            description: el.at('.//description').try(:text),
+                                            quantity_bod: el.at('.//begin_bal').try(:text),
+                                            quantity_eod: el.at('.//end_bal').try(:text),
+                                            quantity_adjusted: el.at('.//adj_qty').try(:text),
+                                            quantity_received: el.at('.//rcpt_qty').try(:text),
+                                            quantity_returned: el.at('.//ret_qty').try(:text),
+                                            quantity_shipped: el.at('.//shp_qty').try(:text),
+                                            quantity_unavailable_adjustments: el.at('.//uad_qty').try(:text),
+                                            transaction_date: el.at('.//trans_date').try(:text)})
         end
-
         Response.new(true, '', {data: records})
       end
     end
-
   end
 end

--- a/lib/active_fulfillment/models/dotcom_distribution/item_summary.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/item_summary.rb
@@ -10,19 +10,17 @@ module ActiveFulfillment
                     :vendor_items
 
       def self.response_from_xml(xml)
-        success = true, message = '', hash = {}, records = []
+        success = true, message = '', records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//item_info").each do |el|
-          hash[:sku] = el.at('.//sku').try(:text)
-          hash[:description] = el.at('.//item_description').try(:text)
-          hash[:last_receipt_date] = el.at('.//last_receipt_date').try(:text)
-          hash[:upc_number] = el.at('.//upc_num').try(:text)
-          hash[:vendor_items] = el.xpath('.//vendor_items//vendor_item').collect do |item|
-            VendorItem.new(cross_ref: item.at('.//vendor_cross_ref').try(:text))
-          end
-          records << ItemSummary.new(hash)
+          records << ItemSummary.new({sku: el.at('.//sku').try(:text),
+                                      description: el.at('.//item_description').try(:text),
+                                      last_receipt_date: el.at('.//last_receipt_date').try(:text),
+                                      upc_number: el.at('.//upc_num').try(:text),
+                                      vendor_items: el.xpath('.//vendor_items//vendor_item').collect { |item|
+                                        VendorItem.new(cross_ref: item.at('.//vendor_cross_ref').try(:text))
+                                      }})
         end
         Response.new(success, '', {data: records})
       end

--- a/lib/active_fulfillment/models/dotcom_distribution/post_item.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/post_item.rb
@@ -31,15 +31,12 @@ module ActiveFulfillment
                     :size
 
       def self.response_from_xml(xml)
-        success = true, message = '', hash = {}, records = []
+        success = true, message = '', records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//item_error").each do |error|
-          hash[:error_description] = error.at('.//error_description').try(:text)
-          hash[:sku] = error.at('.//sku').try(:text)
-
-          records << hash
+          records << {sku: error.at('.//sku').try(:text),
+                      error_description: error.at('.//error_description').try(:text)}
         end
         if records.length > 0
           return Response.new(false, '', {data: records})

--- a/lib/active_fulfillment/models/dotcom_distribution/post_order.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/post_order.rb
@@ -153,12 +153,10 @@ module ActiveFulfillment
         success = true, message = '', hash = {}, records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//order_error").each do |error|
-          hash[:error_description] = error.at('.//error_description').try(:text)
-          hash[:order_number] = error.at('.//order_number').try(:text)
-
-          records << hash
+          records << {order_number: error.at('.//order_number').try(:text),
+                      error_description: error.at('.//error_description').try(:text)}
+                      
         end
         if records.length > 0
           return Response.new(false, '', {data: records})

--- a/lib/active_fulfillment/models/dotcom_distribution/purchase_order.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/purchase_order.rb
@@ -55,22 +55,17 @@ module ActiveFulfillment
       end
 
       def self.response_from_xml(xml)
-        hash = {}
         records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//purchase_order_error").each do |error|
-          hash[:error_description] = error.at('.//error_description').try(:text)
-          hash[:purchase_order_number] = error.at('.//purchase_order_number').try(:text)
-
-          records << hash
+          records << {purchase_order_number: error.at('.//purchase_order_number').try(:text),
+                      error_description: error.at('.//error_description').try(:text)}
         end
         if records.length > 0
           return Response.new(false, '', {data: records})
         end
       end
-
     end
   end
 end

--- a/lib/active_fulfillment/models/dotcom_distribution/return.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/return.rb
@@ -11,18 +11,17 @@ module ActiveFulfillment
                     :return_items
 
       def self.response_from_xml(xml)
-        success = true, message = '', hash = {}, records = []
+        success = true, message = '', records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//Return").each do |el|
           next if el.attributes["nil"]
 
-          hash[:dcd_return_number] = el.at('.//dcd_return_number').try(:text)
-          hash[:department] = el.at('.//department').try(:text)
-          hash[:original_order_number] = el.at('.//original_order_number').try(:text)
-          hash[:return_date] = el.at('.//return_date')
-          hash[:rn] = el.at('.//rn')
+          hash = {dcd_return_number: el.at('.//dcd_return_number').try(:text),
+                  department: el.at('.//department').try(:text),
+                  original_order_number: el.at('.//original_order_number').try(:text),
+                  return_date: el.at('.//return_date'),
+                  rn: el.at('.//rn')}
 
           hash[:return_items] = el.xpath('.//ret_items//ret_item').collect do |item|
             ReturnItem.new(sku: item.at('.//sku').try(:text),

--- a/lib/active_fulfillment/models/dotcom_distribution/ship_method.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/ship_method.rb
@@ -10,22 +10,17 @@ module ActiveFulfillment
                     :shipping_description
 
       def self.response_from_xml(xml)
-        success = true, message = '', hash = {}, records = []
+        success = true, message = '', records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//ship_method").each do |r|
-          hash[:carrier] = r.at('.//carrier').try(:text)
-          hash[:service] = r.at('.//service').try(:text)
-          hash[:shipping_code] = r.at('.//shipping_code').try(:text)
-          hash[:shipping_description] = r.at('.//shipping_description').try(:text)
-
-          records << ShipMethod.new(hash)
+          records << ShipMethod.new(carrier: r.at('.//carrier').try(:text),
+                                    service: r.at('.//service').try(:text),
+                                    shipping_code: r.at('.//shipping_code').try(:text),
+                                    shipping_description: r.at('.//shipping_description').try(:text))
         end
         records
       end
-
     end
-
   end
 end

--- a/lib/active_fulfillment/models/dotcom_distribution/shipment.rb
+++ b/lib/active_fulfillment/models/dotcom_distribution/shipment.rb
@@ -25,30 +25,28 @@ module ActiveFulfillment
                     :ship_items
 
       def self.response_from_xml(xml)
-        success = true, message = '', hash = {}, records = []
+        success = true, message = '', records = []
         doc = Nokogiri.XML(xml)
         doc.remove_namespaces!
-
         doc.xpath("//shipment").each do |el|
-          hash[:client_order_number] = el.at('.//client_order_number').try(:text)
-          hash[:customer_number] = el.at('.//customer_number').try(:text)
-          hash[:dcd_order_number] = el.at('.//dcd_order_number').try(:text)
-          hash[:order_date] = el.at('.//order_date').try(:text)
-          hash[:order_shipping_handling] = el.at('.//order_shipping_handling').try(:text)
-          hash[:order_status] = el.at('.//order_status').try(:text)
-          hash[:order_subtotal] = el.at('.//order_subtotal').try(:text)
-          hash[:order_tax] = el.at('.//order_tax').try(:text)
-          hash[:order_total] = el.at('.//order_total').try(:text)
-          hash[:ship_date] = el.at('.//ship_date').try(:text)
-          hash[:ship_weight] = el.at('.//ship_weight').try(:text)
-          hash[:shipto_addr1] = el.at('.//shipto_addr1').try(:text)
-          hash[:shipto_addr2] = el.at('.//shipto_addr2').try(:text)
-          hash[:shipto_city] = el.at('.//shipto_city').try(:text)
-          hash[:shipto_email_address] = el.at('.//shipto_email_address').try(:text)
-          hash[:shipto_name] = el.at('.//shipto_name').try(:text)
-          hash[:shipto_state] = el.at('.//shipto_state').try(:text)
-          hash[:shipto_zip] = el.at('.//shipto_zip').try(:text)
-
+          hash = {client_order_number: el.at('.//client_order_number').try(:text),
+                  customer_number: el.at('.//customer_number').try(:text),
+                  dcd_order_number: el.at('.//dcd_order_number').try(:text),
+                  order_date: el.at('.//order_date').try(:text),
+                  order_shipping_handling: el.at('.//order_shipping_handling').try(:text),
+                  order_status: el.at('.//order_status').try(:text),
+                  order_subtotal: el.at('.//order_subtotal').try(:text),
+                  order_tax: el.at('.//order_tax').try(:text),
+                  order_total: el.at('.//order_total').try(:text),
+                  ship_date: el.at('.//ship_date').try(:text),
+                  ship_weight: el.at('.//ship_weight').try(:text),
+                  shipto_addr1: el.at('.//shipto_addr1').try(:text),
+                  shipto_addr2: el.at('.//shipto_addr2').try(:text),
+                  shipto_city: el.at('.//shipto_city').try(:text),
+                  shipto_email_address: el.at('.//shipto_email_address').try(:text),
+                  shipto_name: el.at('.//shipto_name').try(:text),
+                  shipto_state: el.at('.//shipto_state').try(:text),
+                  shipto_zip: el.at('.//shipto_zip').try(:text)}
           hash[:ship_items] = [] if hash[:ship_items].nil? && el.xpath('.//ship_items').size > 0
 
           el.xpath('.//ship_item').each do |item|
@@ -69,7 +67,6 @@ module ActiveFulfillment
           end
           records << Shipment.new(hash)
         end
-
         Response.new(true, '', {data: records})
       end
     end

--- a/test/fixtures/xml/dotcom_distribution/item_error_response.xml
+++ b/test/fixtures/xml/dotcom_distribution/item_error_response.xml
@@ -1,0 +1,16 @@
+<response xmlns="http://dcd/datacontracts/post_item" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <item_errors xmlns:a="http://schemas.datacontract.org/2004/07/DCDAPIService">
+    <a:item_error>
+      <a:error_description>The First Error</a:error_description>
+      <a:sku>C028</a:sku>
+    </a:item_error>
+    <a:item_error>
+      <a:error_description>The Second Error</a:error_description>
+      <a:sku>C028A</a:sku>
+    </a:item_error>
+    <a:item_error>
+      <a:error_description>Something completely different</a:error_description>
+      <a:sku>C028K</a:sku>
+    </a:item_error>
+  </item_errors>
+</response>

--- a/test/unit/models/dotcom_distribution/post_item_test.rb
+++ b/test/unit/models/dotcom_distribution/post_item_test.rb
@@ -32,6 +32,18 @@ class PostItemTest < Minitest::Test
     end
   end
 
+  def test_error_response_parsing
+    error_xml = xml_fixture('dotcom_distribution/item_error_response')
+    response = PostItem.response_from_xml(error_xml)
+    assert_equal false, response.success?
+    records = response.params["data"]
+    assert_equal 3, records.length
+    assert_equal 'C028', records[0][:sku]
+    assert_equal 'The First Error', records[0][:error_description]
+    assert_equal 'C028K', records[-1][:sku]
+    assert_equal 'Something completely different', records[-1][:error_description]
+  end
+
   def check_item(item)
     assert_equal item.at('.//sku').text, @item[:sku]
     assert_equal item.at('.//description').text, @item[:description]
@@ -59,5 +71,4 @@ class PostItemTest < Minitest::Test
     assert_equal item.at('.//size').text, ''
     assert_equal item.at('.//long-description').text, ''
   end
-
 end


### PR DESCRIPTION
All of them were stomping on previous values by creating one hash then
filling that in and adding it to the array of returned values. Since
there was only one hash, the reponse always ended up with N references
to the same last value that was created.
