### PR TITLE
Removed rubysl-resolv dependency and explicit require

### DIFF
--- a/active_fulfillment.gemspec
+++ b/active_fulfillment.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency('builder', '>= 2.0.0')
   s.add_dependency('nokogiri', '>= 1.6')
   s.add_dependency('active_utils', '~> 3.0')
-  s.add_dependency('rubysl-resolv')
   s.add_dependency('thor')
 
   s.add_development_dependency('rake')

--- a/lib/active_fulfillment/services/shopify_api.rb
+++ b/lib/active_fulfillment/services/shopify_api.rb
@@ -1,5 +1,4 @@
 require 'active_support/core_ext/object/to_query'
-require 'resolv'
 
 module ActiveFulfillment
   class ShopifyAPIService < Service


### PR DESCRIPTION
@jimm I am trying to improve start-up time for our dev environment and at some point I got a lot of `already initialized constant` warnings:

```
/Users/kgorin/.rvm/gems/ruby-2.3.1@Candi/gems/rubysl-resolv-2.1.2/lib/rubysl/resolv/resolv.rb:172: warning: already initialized constant Resolv::Hosts::DefaultFileName
/Users/kgorin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/resolv.rb:175: warning: previous definition of DefaultFileName was here
/Users/kgorin/.rvm/gems/ruby-2.3.1@Candi/gems/rubysl-resolv-2.1.2/lib/rubysl/resolv/resolv.rb:285: warning: already initialized constant Resolv::DNS::Port
/Users/kgorin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/resolv.rb:288: warning: previous definition of Port was here
/Users/kgorin/.rvm/gems/ruby-2.3.1@Candi/gems/rubysl-resolv-2.1.2/lib/rubysl/resolv/resolv.rb:290: warning: already initialized constant Resolv::DNS::UDPSize
/Users/kgorin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/resolv.rb:293: warning: previous definition of UDPSize was here
/Users/kgorin/.rvm/gems/ruby-2.3.1@Candi/gems/rubysl-resolv-2.1.2/lib/rubysl/resolv/resolv.rb:624: warning: already initialized constant Resolv::DNS::RequestID
/Users/kgorin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/resolv.rb:627: warning: previous definition of RequestID was here
/Users/kgorin/.rvm/gems/ruby-2.3.1@Candi/gems/rubysl-resolv-2.1.2/lib/rubysl/resolv/resolv.rb:625: warning: already initialized constant Resolv::DNS::RequestIDMutex
/Users/kgorin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/resolv.rb:628: warning: previous definition of RequestIDMutex was here
/Users/kgorin/.rvm/gems/ruby-2.3.1@Candi/gems/rubysl-resolv-2.1.2/lib/rubysl/resolv/resolv.rb:1077: warning: already initialized constant Resolv::DNS::Config::InitialTimeout
/Users/kgorin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/resolv.rb:1084: warning: previous definition of InitialTimeout was here
```

I noticed that we have `rubysl-resolv` in gem dependencies and explicitly require it in `shopify_api.rb`, but looks like it is available in ruby 2.3 by default. Can we safely remove this dependency?